### PR TITLE
feat: add precision configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ sensor:
 sensor:
   - platform: apparent_temperature
     name: 'Basement Feels Like Temperature'
+    precision: 2
     source:
       - sensor.basement_temperature
       - sensor.basement_humidity
@@ -94,6 +95,10 @@ I put a lot of work into making this repo and component available and updated to
 
 > **_Note_**:
 > You can use site [uuidgenerator.net](https://www.uuidgenerator.net/) to generate unique ID's.
+
+**precision**\
+  _(integer) (Optional) (Default value: 1)_\
+  Number of decimal places to display (0-6).
 
 ## Track updates
 

--- a/custom_components/apparent_temperature/sensor.py
+++ b/custom_components/apparent_temperature/sensor.py
@@ -67,11 +67,16 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_PRECISION = "precision"
+
 PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_SOURCE): cv.entity_ids,
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(CONF_UNIQUE_ID): cv.string,
+        vol.Optional(CONF_PRECISION, default=1): vol.All(
+            vol.Coerce(int), vol.Range(min=0, max=6)
+        ),
     }
 )
 
@@ -93,6 +98,7 @@ async def async_setup_platform(
                 config.get(CONF_UNIQUE_ID),
                 config.get(CONF_NAME),
                 expand_entity_ids(hass, config.get(CONF_SOURCE)),
+                config.get(CONF_PRECISION),
             )
         ]
     )
@@ -107,14 +113,18 @@ class ApparentTemperatureSensor(SensorEntity):
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_should_poll = False
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
-    _attr_suggested_display_precision = 1
 
     def __init__(
-        self, unique_id: str | None, name: str | None, sources: list[str]
+        self,
+        unique_id: str | None,
+        name: str | None,
+        sources: list[str],
+        precision: int = 1,
     ) -> None:
         """Class initialization."""
         self._attr_unique_id = unique_id
         self._attr_native_value = None
+        self._attr_suggested_display_precision = precision
 
         self._name = name
         self._sources = sources


### PR DESCRIPTION
## Breaking change

N/A - This is a new feature, not a breaking change.

## Proposed change

This PR adds an optional `precision` configuration parameter that allows users to control the number of decimal places displayed for the apparent temperature sensor value.

Users can now customize the display precision from 0 to 6 decimal places based on their preference. If not specified, the default is 1 decimal place. Users who want more precision can configure a higher value (e.g., `precision: 2` for two decimal places).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an this integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:

```yaml
# Example configuration.yaml
sensor:
  # Use default precision (1 decimal place)
  - platform: apparent_temperature
    source: weather.home

  # Custom precision - 2 decimal places
  - platform: apparent_temperature
    name: 'Basement Feels Like Temperature'
    precision: 2  # Display 2 decimal places (e.g., 20.45°C)
    source:
      - sensor.basement_temperature
      - sensor.basement_humidity
```

## Additional information

- This PR fixes or closes issue: fixes #180
- This PR is related to issue: N/A

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Black (`black --fast custom_components`)

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated to README.md
